### PR TITLE
installation: fix invenio_access imports

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -84,6 +84,7 @@ Invenio module for information retrieval.
 - Raja Sripada <rsripada@cern.ch>
 - Raquel Jimenez Encinar <r.jimenez.encinar@gmail.com>
 - Roman Chyla <roman.chyla@gmail.com>
+- Sami Hiltunen <sami.mikael.hiltunen@cern.ch>
 - Samuele Carli <samuele.carli@cern.ch>
 - Samuele Kaplun <samuele.kaplun@cern.ch>
 - Theodoropoulos Theodoros <theod@lib.auth.gr>

--- a/invenio_search/utils.py
+++ b/invenio_search/utils.py
@@ -134,7 +134,7 @@ def get_most_popular_field_values(recids, tags, exclude_values=None,
 def get_permitted_restricted_collections(user_info,
                                          recreate_cache_if_needed=True):
     """Return a list of restricted collection with user is authorization."""
-    from invenio.modules.access.engine import acc_authorize_action
+    from invenio_access.engine import acc_authorize_action
 
     if recreate_cache_if_needed:
         restricted_collection_cache.recreate_cache_if_needed()

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -22,8 +22,9 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
--e git+git://github.com/inveniosoftware/invenio-query-parser.git#egg=invenio-query-parser
--e git+git://github.com/inveniosoftware/invenio-upgrader.git#egg=invenio-upgrader
+-e git+git://github.com/inveniosoftware/invenio-access.git#egg=invenio-access
 -e git+git://github.com/inveniosoftware/invenio-accounts.git#egg=invenio-accounts
--e git+git://github.com/inveniosoftware/invenio-knowledge.git#egg=invenio-knowledge
 -e git+git://github.com/inveniosoftware/invenio-formatter.git#egg=invenio-formatter
+-e git+git://github.com/inveniosoftware/invenio-knowledge.git#egg=invenio-knowledge
+-e git+git://github.com/inveniosoftware/invenio-upgrader.git#egg=invenio-upgrader
+-e git+git://github.com/inveniosoftware/invenio-query-parser.git#egg=invenio-query-parser

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ history = open('CHANGES.rst').read()
 requirements = [
     'Flask>=0.10.1',
     'six>=1.7.2',
+    'invenio-accounts>=0.1.0',
     'invenio-query-parser>=0.2',
     'invenio-upgrader>=0.1.0',
     'invenio-accounts>=0.1.0',
@@ -54,6 +55,7 @@ test_requirements = [
 
 
 class PyTest(TestCommand):
+
     """PyTest Test."""
 
     user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]


### PR DESCRIPTION
* Adds missing `invenio_access` dependency and amends past upgrade
  recipes following its separation into standalone package.

Signed-off-by: Sami Hiltunen <sami.mikael.hiltunen@cern.ch>