### PR TITLE
installation: fix invenio_base imports

### DIFF
--- a/.travis.invenio.cfg
+++ b/.travis.invenio.cfg
@@ -36,5 +36,5 @@ PACKAGES = [
     'invenio_accounts',
     'invenio_formatter',
     'invenio_upgrader',
-    'invenio.base',
+    'invenio_base',
 ]

--- a/invenio_search/api.py
+++ b/invenio_search/api.py
@@ -25,7 +25,7 @@ import pypeg2
 
 from flask_login import current_user
 
-from invenio.base.helpers import unicodifier
+from invenio_base.helpers import unicodifier
 
 from werkzeug.utils import cached_property
 

--- a/invenio_search/bundles.py
+++ b/invenio_search/bundles.py
@@ -21,7 +21,7 @@
 
 from __future__ import unicode_literals
 
-from invenio.base.bundles import invenio as _i, jquery as _j
+from invenio_base.bundles import invenio as _i, jquery as _j
 from invenio.ext.assets import Bundle, RequireJSFilter
 
 js = Bundle(

--- a/invenio_search/cache.py
+++ b/invenio_search/cache.py
@@ -22,7 +22,7 @@
 from intbitset import intbitset
 from flask import current_app
 
-from invenio.base.globals import cfg
+from invenio_base.globals import cfg
 from invenio.ext.cache import cache
 from invenio.legacy.miscutil.data_cacher import DataCacher, DataCacherProxy
 from invenio.utils.hash import md5

--- a/invenio_search/enhancers/collection_filter.py
+++ b/invenio_search/enhancers/collection_filter.py
@@ -19,7 +19,7 @@
 
 """Generate filter for retricted collections."""
 
-from invenio.base.globals import cfg
+from invenio_base.globals import cfg
 
 from invenio_query_parser.ast import (
     AndOp, DoubleQuotedValue, Keyword, KeywordOp, NotOp, OrOp

--- a/invenio_search/facet_builders.py
+++ b/invenio_search/facet_builders.py
@@ -26,7 +26,7 @@ from itertools import groupby
 from operator import itemgetter
 from six import iteritems
 
-from invenio.base.globals import cfg
+from invenio_base.globals import cfg
 from invenio_collections.models import Collection
 
 from .cache import (

--- a/invenio_search/forms.py
+++ b/invenio_search/forms.py
@@ -22,7 +22,7 @@
 from flask import url_for
 from six import iteritems
 
-from invenio.base.i18n import _
+from invenio_base.i18n import _
 from invenio_knowledge.api import get_kb_mappings
 from invenio.utils.forms import AutocompleteField, InvenioBaseForm, \
     RowWidget

--- a/invenio_search/models.py
+++ b/invenio_search/models.py
@@ -25,7 +25,7 @@ from flask import g, request
 
 from flask_login import current_user
 
-from invenio.base.globals import cfg
+from invenio_base.globals import cfg
 from invenio.ext.sqlalchemy import db
 from invenio_accounts.models import User
 

--- a/invenio_search/searchext/services/CollectionNameSearchService.py
+++ b/invenio_search/searchext/services/CollectionNameSearchService.py
@@ -22,7 +22,7 @@ WebSearch service to search in collection names
 import re
 import urllib
 from invenio_search.services import ListLinksService
-from invenio.base.i18n import gettext_set_language
+from invenio_base.i18n import gettext_set_language
 from invenio.legacy.bibindex.engine_stemmer import stem
 from invenio.legacy.dbquery import get_table_update_time
 from invenio.config import \

--- a/invenio_search/searchext/services/FAQKBService.py
+++ b/invenio_search/searchext/services/FAQKBService.py
@@ -21,7 +21,7 @@ WebSearch service to answer based on BibKnowledge KB
 """
 from invenio.config import CFG_SITE_LANG
 from invenio_search.services import KnowledgeBaseService
-from invenio.base.i18n import gettext_set_language
+from invenio_base.i18n import gettext_set_language
 
 __plugin_version__ = "Search Service Plugin API 1.0"
 

--- a/invenio_search/searchext/services/JournalHintService.py
+++ b/invenio_search/searchext/services/JournalHintService.py
@@ -24,7 +24,7 @@ when the request is a journal reference
 from invenio_search.services import SearchService
 from invenio.config import (CFG_SITE_URL,
                             CFG_SITE_LANG)
-from invenio.base.i18n import gettext_set_language
+from invenio_base.i18n import gettext_set_language
 from invenio.legacy.search_engine import perform_request_search, print_record
 from invenio.legacy.webuser import collect_user_info
 from urllib import urlencode

--- a/invenio_search/searchext/services/LHCBeamStatusService.py
+++ b/invenio_search/searchext/services/LHCBeamStatusService.py
@@ -20,7 +20,7 @@
 WebSearch service to display LHC beam status
 """
 from invenio_search.services import SearchService
-from invenio.base.i18n import gettext_set_language
+from invenio_base.i18n import gettext_set_language
 from invenio.config import CFG_SITE_LANG, CFG_SITE_URL
 
 __plugin_version__ = "Search Service Plugin API 1.0"

--- a/invenio_search/services.py
+++ b/invenio_search/services.py
@@ -25,7 +25,7 @@ from invenio_knowledge.api import get_kb_mappings
 from invenio.legacy.miscutil.data_cacher import DataCacher
 from invenio.legacy.bibindex.engine_stemmer import stem
 from invenio.legacy.dbquery import get_table_update_time
-from invenio.base.i18n import gettext_set_language
+from invenio_base.i18n import gettext_set_language
 from invenio.legacy import template
 
 from . import registry

--- a/invenio_search/user_settings.py
+++ b/invenio_search/user_settings.py
@@ -22,7 +22,7 @@
 
 from flask import url_for
 from flask_login import current_user
-from invenio.base.i18n import _
+from invenio_base.i18n import _
 from invenio.ext.sqlalchemy import db
 from invenio.ext.template import render_template_to_string
 from .models import UserQuery

--- a/invenio_search/utils.py
+++ b/invenio_search/utils.py
@@ -28,7 +28,7 @@ from intbitset import intbitset
 from six import iteritems, string_types
 from werkzeug.utils import import_string
 
-from invenio.base.globals import cfg
+from invenio_base.globals import cfg
 from invenio_collections.cache import (
     get_collection_allchildren,
     restricted_collection_cache,

--- a/invenio_search/views/search.py
+++ b/invenio_search/views/search.py
@@ -51,9 +51,9 @@ from flask_breadcrumbs import (default_breadcrumb_root,
                                register_breadcrumb)
 from flask_login import current_user
 
-from invenio.base.decorators import wash_arguments
-from invenio.base.globals import cfg
-from invenio.base.i18n import _
+from invenio_base.decorators import wash_arguments
+from invenio_base.globals import cfg
+from invenio_base.i18n import _
 from invenio_collections.decorators import check_collection
 from invenio_formatter import (
     format_records, get_output_format_content_type,

--- a/invenio_search/walkers/elasticsearch.py
+++ b/invenio_search/walkers/elasticsearch.py
@@ -19,7 +19,7 @@
 
 """Implement AST convertor to Elastic Search DSL."""
 
-from invenio.base.globals import cfg
+from invenio_base.globals import cfg
 from invenio_query_parser.ast import (
     AndOp, KeywordOp, OrOp,
     NotOp, Keyword, Value,

--- a/invenio_search/washers.py
+++ b/invenio_search/washers.py
@@ -20,7 +20,7 @@
 import re
 import time
 
-from invenio.base.globals import cfg
+from invenio_base.globals import cfg
 from invenio.utils.datastructures import LazyDict
 from invenio.utils.text import wash_for_utf8
 

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -24,6 +24,7 @@
 
 -e git+git://github.com/inveniosoftware/invenio-access.git#egg=invenio-access
 -e git+git://github.com/inveniosoftware/invenio-accounts.git#egg=invenio-accounts
+-e git+git://github.com/inveniosoftware/invenio-base.git#egg=invenio-base
 -e git+git://github.com/inveniosoftware/invenio-formatter.git#egg=invenio-formatter
 -e git+git://github.com/inveniosoftware/invenio-knowledge.git#egg=invenio-knowledge
 -e git+git://github.com/inveniosoftware/invenio-upgrader.git#egg=invenio-upgrader

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ requirements = [
     'six>=1.7.2',
     'invenio-access>=0.1.0',
     'invenio-accounts>=0.1.2',
+    'invenio-base>=0.1.0',
     'invenio-formatter>=0.2.1',
     'invenio-knowledge>=0.1.0',
     'invenio-query-parser>=0.2',


### PR DESCRIPTION
* FIX Adds missing `invenio_base` dependency and amends past
  upgrade recipes following its separation into standalone package.

Signed-off-by: Sami Hiltunen <sami.mikael.hiltunen@cern.ch>