### PR TITLE
installation: explicit `requests` dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ install_requires = [
     'pyPEG2>=2.15.2',
     'elasticsearch>=2.0.0',
     'invenio-query-parser>=0.4.1',
+    'requests>=2.4.0',
 ]
 
 packages = find_packages()


### PR DESCRIPTION
* FIX Adds `requests` dependency that is explicitly required for
  `elasticsearch.connection.RequestsHttpConnection` transport class.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>