### PR TITLE
ext: flush and refresh indices

### DIFF
--- a/examples/app.py
+++ b/examples/app.py
@@ -66,7 +66,7 @@ Try to perform some queries from browser:
 
 from __future__ import absolute_import, print_function
 
-from elasticsearch_dsl.query import Bool, Q, QueryString, Terms
+from elasticsearch_dsl.query import Bool, Q, QueryString
 from flask import Flask, jsonify, request
 from flask_babelex import Babel
 from flask_cli import FlaskCLI
@@ -77,7 +77,7 @@ from invenio_accounts import InvenioAccounts
 from invenio_accounts.views import blueprint
 from invenio_db import InvenioDB
 
-from invenio_search import InvenioSearch, RecordsSearch, current_search_client
+from invenio_search import InvenioSearch, RecordsSearch
 
 # Create Flask application
 app = Flask(__name__)
@@ -106,6 +106,8 @@ search.register_mappings('records', 'data')
 
 
 class ExampleSearch(RecordsSearch):
+    """Example search class."""
+
     class Meta:
         index = 'demo'
         doc_types = ['example']
@@ -113,6 +115,7 @@ class ExampleSearch(RecordsSearch):
         facets = {}
 
     def __init__(self, **kwargs):
+        """Initialize instance."""
         super(ExampleSearch, self).__init__(**kwargs)
         if not current_user.is_authenticated:
             self.query = self.query._proxied & Q(
@@ -125,7 +128,7 @@ def index():
     """Query Elasticsearch using Invenio query syntax."""
     page = request.values.get('page', 1, type=int)
     size = request.values.get('size', 2, type=int)
-    search = ExampleSearch()[(page-1)*size:page*size]
+    search = ExampleSearch()[(page - 1) * size:page * size]
     if 'q' in request.values:
         search = search.query(QueryString(query=request.values.get('q')))
 

--- a/invenio_search/ext.py
+++ b/invenio_search/ext.py
@@ -77,8 +77,7 @@ class _SearchState(object):
                 assert index_name not in data, 'Duplicate index'
                 data[index_name] = self.mappings[index_name] = \
                     resource_filename(
-                        package_name, os.path.join(resource_name, filename)
-                    )
+                        package_name, os.path.join(resource_name, filename))
                 self.number_of_indexes += 1
 
             aliases[root_name] = data
@@ -107,6 +106,20 @@ class _SearchState(object):
         if self._client is None:
             self._client = self._client_builder()
         return self._client
+
+    def flush_and_refresh(self, index):
+        """Flush and refresh one or more indices.
+
+        .. warning::
+
+           Do not call this method unless you know what you are doing. This
+           method is only intended to be called during tests.
+        """
+        self.client.indices.flush(wait_if_ongoing=True, index=index)
+        self.client.indices.refresh(index=index)
+        self.client.cluster.health(
+            wait_for_status='yellow', request_timeout=30)
+        return True
 
     def create(self, ignore=None):
         """Yield tuple with created index name and responses from a client."""

--- a/tests/test_invenio_search.py
+++ b/tests/test_invenio_search.py
@@ -32,7 +32,7 @@ from flask import Flask
 from flask_cli import FlaskCLI
 from mock import patch
 
-from invenio_search import InvenioSearch, current_search_client
+from invenio_search import InvenioSearch, current_search, current_search_client
 from invenio_search.utils import schema_to_index
 
 
@@ -55,6 +55,12 @@ def test_init():
     assert 'invenio-search' not in app.extensions
     ext.init_app(app)
     assert 'invenio-search' in app.extensions
+
+
+def test_flush_and_refresh(app):
+    """Test flush and refresh."""
+    search = app.extensions['invenio-search']
+    search.flush_and_refresh('_all')
 
 
 def test_client_reference():


### PR DESCRIPTION
* Adds method for flushing and refreshing one or more indices during
  tests.

* Fixes some PEP8/257 errors.

Signed-off-by: Lars Holm Nielsen <lars.holm.nielsen@cern.ch>