### PR TITLE
cli: registration of ES templates

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -37,4 +37,4 @@ prune docs/_build
 recursive-include docs *.bat *.py *.rst Makefile
 recursive-include examples *.json *.py *.sh *.txt
 recursive-include invenio_search *.py
-recursive-include tests *.json *.py
+recursive-include tests *.json *.py *.txt

--- a/invenio_search/cli.py
+++ b/invenio_search/cli.py
@@ -60,6 +60,12 @@ def init(force):
             length=current_search.number_of_indexes) as bar:
         for name, response in bar:
             bar.label = name
+    click.secho('Putting templates...', fg='green', bold=True, file=sys.stderr)
+    with click.progressbar(
+            current_search.put_templates(ignore=[400] if force else None),
+            length=len(current_search.templates.keys())) as bar:
+        for response in bar:
+            bar.label = response
 
 
 @index.command()

--- a/tests/data/templates/file_download_v1.json
+++ b/tests/data/templates/file_download_v1.json
@@ -1,0 +1,45 @@
+{
+  "template": "events-stats_file_download-*",
+  "settings": {
+    "index": {
+      "refresh_interval": "5s"
+    }
+  },
+  "mappings": {
+    "filedownload": {
+      "_source": {
+        "enabled": false
+      },
+      "_all": {
+        "enabled": false
+      },
+      "date_detection": false,
+      "numeric_detection": false,
+      "properties": {
+        "@timestamp": {
+          "type": "date"
+        },
+        "bucket": {
+          "type": "string",
+          "index": "not_analyzed"
+        },
+        "key": {
+          "type": "string",
+          "index": "not_analyzed"
+        },
+        "country": {
+          "type": "string",
+          "index": "not_analyzed"
+        },
+        "visitor_id": {
+          "type": "string",
+          "index": "not_analyzed"
+        },
+        "collection": {
+          "type": "string",
+          "index": "not_analyzed"
+        }
+      }
+    }
+  }
+}

--- a/tests/data/templates/record_view_v1.json
+++ b/tests/data/templates/record_view_v1.json
@@ -1,0 +1,52 @@
+{
+  "template": "events-stats_record_view-*",
+  "settings": {
+    "index": {
+      "refresh_interval": "5s"
+    }
+  },
+  "mappings": {
+    "recordview": {
+      "_source": {
+        "enabled": false
+      },
+      "_all": {
+        "enabled": false
+      },
+      "date_detection": false,
+      "numeric_detection": false,
+      "properties": {
+        "@timestamp": {
+          "type": "date"
+        },
+        "id": {
+          "type": "string",
+          "index": "not_analyzed"
+        },
+        "type": {
+          "type": "string",
+          "index": "not_analyzed"
+        },
+        "value": {
+          "type": "string",
+          "index": "not_analyzed"
+        },
+        "labels": {
+          "type": "string",
+          "index": "not_analyzed"
+        },
+        "country": {
+          "type": "string",
+          "index": "not_analyzed"
+        },
+        "visitor_id": {
+          "type": "string",
+          "index": "not_analyzed"
+        }
+      }
+    }
+  },
+  "aliases": {
+    "events-recordview": {}
+  }
+}

--- a/tests/data/templates/subdirectory/file_download_v1.json
+++ b/tests/data/templates/subdirectory/file_download_v1.json
@@ -1,0 +1,45 @@
+{
+  "template": "events-stats_file_download-*",
+  "settings": {
+    "index": {
+      "refresh_interval": "5s"
+    }
+  },
+  "mappings": {
+    "filedownload": {
+      "_source": {
+        "enabled": false
+      },
+      "_all": {
+        "enabled": false
+      },
+      "date_detection": false,
+      "numeric_detection": false,
+      "properties": {
+        "@timestamp": {
+          "type": "date"
+        },
+        "bucket": {
+          "type": "string",
+          "index": "not_analyzed"
+        },
+        "key": {
+          "type": "string",
+          "index": "not_analyzed"
+        },
+        "country": {
+          "type": "string",
+          "index": "not_analyzed"
+        },
+        "visitor_id": {
+          "type": "string",
+          "index": "not_analyzed"
+        },
+        "collection": {
+          "type": "string",
+          "index": "not_analyzed"
+        }
+      }
+    }
+  }
+}

--- a/tests/test_invenio_search.py
+++ b/tests/test_invenio_search.py
@@ -106,13 +106,13 @@ def test_schema_to_index(schema_url, result):
     assert result == schema_to_index(schema_url)
 
 
-def test_load_entry_point_group():
+def test_load_entry_point_group(template_entrypoints):
     """Test entry point loading."""
     app = Flask('testapp')
     ext = InvenioSearch(app)
     ep_group = 'test'
 
-    def mock_entry_points(group=None):
+    def mock_entry_points_mappings(group=None):
         assert group == ep_group
 
         class ep(object):
@@ -123,6 +123,12 @@ def test_load_entry_point_group():
         yield ep
 
     assert len(ext.mappings) == 0
-    with patch('invenio_search.ext.iter_entry_points', mock_entry_points):
-        ext.load_entry_point_group(entry_point_group=ep_group)
+    with patch('invenio_search.ext.iter_entry_points',
+               mock_entry_points_mappings):
+        ext.load_entry_point_group_mappings(
+            entry_point_group_mappings=ep_group)
     assert len(ext.mappings) == 3
+
+    with patch('invenio_search.ext.iter_entry_points',
+               return_value=template_entrypoints('invenio_search.templates')):
+        assert len(ext.templates.keys()) == 3


### PR DESCRIPTION
- ADDS to the `index init` command the registration of the
  ES templates, loaded from the entrypoint 'invenio_search.templates'

Signed-off-by: Dinos Kousidis <konstantinos.kousidis@cern.ch>