### PR TITLE
api: use minimum_should_match: 1 in filter context

### DIFF
--- a/invenio_search/api.py
+++ b/invenio_search/api.py
@@ -76,7 +76,7 @@ class RecordsSearch(Search):
 
         default_filter = getattr(self.Meta, 'default_filter', None)
         if default_filter:
-            self.query = Bool(filter=default_filter)
+            self.query = Bool(minimum_should_match=1, filter=default_filter)
 
     def get_record(self, id_):
         """Return a record by its identifier.

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -95,7 +95,8 @@ def test_elasticsearch_query(app):
         g.public = 1
         q = TestSearch()
         assert q.to_dict()['query'] == {
-            'bool': {'filter': [{'terms': {'public': 1}}]}
+            'bool': {'minimum_should_match': 1,
+                     'filter': [{'terms': {'public': 1}}]}
         }
         g.public = 0
         q = TestSearch()


### PR DESCRIPTION
* When creating a RecordsSearch instance with a default filter, i.e. a
  `bool` query with a `filter`, `minimum_should_match` should be
  explicitly set, otherwise a document will match the bool query even if
  none of the `should` queries match, according to `bool`
  query documentation.

Signed-off-by: Chris Aslanoglou <chris.aslanoglou@gmail.com>

---
You can see more info on what motivated this PR, here: inspirehep/inspire-next#2829.