### PR TITLE
api: added preference param to eliminate ES bouncing issue

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.


### PR DESCRIPTION
* added a method to RecordsSearch to return a new instance of Search
  with a new query param preference. The value of the param will not
  change for requests coming from the same user.

* closes #106