### PR TITLE
cli: fix output format of `index list`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,9 +43,8 @@ services:
 
 env:
   global:
-    - ES2_DOWNLOAD_URL="https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.2.0/elasticsearch-2.2.0.tar.gz"
-    - ES5_DOWNLOAD_URL="https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.0.0.tar.gz"
-    - ES6_DOWNLOAD_URL="https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.0.0.tar.gz"
+    - ES2_DOWNLOAD_URL="https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.4.2/elasticsearch-2.4.2.tar.gz"
+    - ES5_DOWNLOAD_URL="https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.6.4.tar.gz"
     - ES_HOST=127.0.0.1
     - SQLALCHEMY_DATABASE_URI="postgresql+psycopg2://postgres@localhost:5432/invenio"
   matrix:

--- a/invenio_search/cli.py
+++ b/invenio_search/cli.py
@@ -109,17 +109,18 @@ def create(index_name, body, force, verbose):
 @with_appcontext
 def list_cmd(only_active, only_aliases, verbose):
     """List indices."""
-    def _tree_print(d, rec_list=None, verbose=False):
+    def _tree_print(d, rec_list=None, verbose=False, indent=2):
         # Note that on every recursion rec_list is copied,
         # which might not be very effective for very deep dictionaries.
         rec_list = rec_list or []
         for idx, key in enumerate(sorted(d)):
-            line = ['│  ' if i == 1 else '   ' for i in rec_list]
-            line.append('├──')
+            line = (['│' + ' ' * indent
+                     if i == 1 else ' ' * (indent+1) for i in rec_list])
+            line.append('└──' if len(d)-1 == idx else '├──')
             click.echo(''.join(line), nl=False)
             if isinstance(d[key], dict):
                 click.echo(key)
-                new_rec_list = rec_list + [0 if len(d) == (idx - 1) else 1]
+                new_rec_list = rec_list + [0 if len(d)-1 == idx else 1]
                 _tree_print(d[key], new_rec_list, verbose)
             else:
                 leaf_txt = '{} -> {}'.format(key, d[key]) if verbose else key

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -132,11 +132,11 @@ def test_list(app):
     result = runner.invoke(cmd, ['list'], obj=script_info)
     assert result.output == (
         u"├──authors\n"
-        u"│  ├──authors-authors-v1.0.0\n"
-        u"├──records *\n"
-        u"│  ├──records-authorities\n"
-        u"│  │  ├──records-authorities-authority-v1.0.0\n"
-        u"│  ├──records-bibliographic\n"
-        u"│  │  ├──records-bibliographic-bibliographic-v1.0.0\n"
-        u"│  ├──records-default-v1.0.0\n\n"
+        u"│  └──authors-authors-v1.0.0\n"
+        u"└──records *\n"
+        u"   ├──records-authorities\n"
+        u"   │  └──records-authorities-authority-v1.0.0\n"
+        u"   ├──records-bibliographic\n"
+        u"   │  └──records-bibliographic-bibliographic-v1.0.0\n"
+        u"   └──records-default-v1.0.0\n\n"
     )


### PR DESCRIPTION
* Fixes output format of `index list` which was broken in a previous
  commit (possibly 9daeadb97dc72e713ff3d5b29e0feb3ac778985c)

Signed-off-by: Harri Hirvonsalo <harri.hirvonsalo@cern.ch>