### PR TITLE
installation: idna/urllib3 dependency resolution

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,12 @@ setup_requires = [
 
 install_requires = [
     'Flask>=0.11.1',
-    'requests>=2.4.0',
+    # elasticsearch has hard version range dependency on urllib3
+    # requests has hard version range dependency on idna
+    # Every time idna and urllib3 are updated, installation breaks because
+    # elasticsearch and requests dependencies are not resolved properly.
+    'urllib3<1.23,>=1.21.1',  # from elasticsearch and requests
+    'idna>=2.5,<2.8', # from requests
 ]
 
 packages = find_packages()


### PR DESCRIPTION
* Fixes issue that would cause Invenio installation to break everytime
  new versions of idna and urllib3 were being released, since
  elasticsearch and requests specify hard dependencies on these modules.