### PR TITLE
global: allow using an index prefix

### DIFF
--- a/invenio_search/config.py
+++ b/invenio_search/config.py
@@ -79,3 +79,19 @@ Please refer to `Elasticsearch min_score documentation
 <https://www.elastic.co/guide/en/elasticsearch/reference/current/
 search-request-min-score.html>`_ for more information.
 """
+
+SEARCH_INDEX_PREFIX = ''
+"""Any index and alias will be prefixed with this string.
+
+Useful to host multiple instances of the app on the same elasticsearch cluster,
+for example on one app you can set it to `dev-` and on the other to `prod-`,
+and each will create non-colliding indices prefixed with the corresponding
+stirng.
+
+For example if you want to prefix all your indices and aliases with `prod-`:
+
+.. code-block:: python
+
+    # in your config.py
+    SEARCH_INDEX_PREFIX = 'prod-'
+"""

--- a/invenio_search/ext.py
+++ b/invenio_search/ext.py
@@ -97,7 +97,7 @@ class _SearchState(object):
             package_name = '{}.v{}'.format(package_name, ES_VERSION[0])
 
         def _walk_dir(aliases, *parts):
-            root_name = build_index_name(*parts)
+            root_name = build_index_name(self.app, *parts)
             resource_name = os.path.join(*parts)
 
             if root_name not in aliases:
@@ -106,7 +106,10 @@ class _SearchState(object):
             data = aliases.get(root_name, {})
 
             for filename in resource_listdir(package_name, resource_name):
-                index_name = build_index_name(*(parts + (filename, )))
+                index_name = build_index_name(
+                    self.app,
+                    *(parts + (filename, ))
+                )
                 file_path = os.path.join(resource_name, filename)
 
                 if resource_isdir(package_name, file_path):
@@ -152,7 +155,10 @@ class _SearchState(object):
             resource_name = os.path.join(*parts)
 
             for filename in resource_listdir(module_name, resource_name):
-                template_name = build_index_name(*(parts[1:] + (filename, )))
+                template_name = build_index_name(
+                    self.app,
+                    *(parts[1:] + (filename, ))
+                )
                 file_path = os.path.join(resource_name, filename)
 
                 if resource_isdir(module_name, file_path):

--- a/tests/test_invenio_search.py
+++ b/tests/test_invenio_search.py
@@ -17,7 +17,6 @@ from flask import Flask
 from mock import patch
 
 from invenio_search import InvenioSearch, current_search, current_search_client
-from invenio_search.utils import schema_to_index
 
 
 def test_version():
@@ -75,19 +74,6 @@ def test_default_client(app):
     current_search_client.cluster.health(
         wait_for_status='yellow', request_timeout=1
     )
-
-
-@pytest.mark.parametrize(('schema_url', 'result'), [
-    ('invalidfileextension',
-     (None, None)),
-    ('records/record-v1.0.0.json',
-     ('records-record-v1.0.0', 'record-v1.0.0')),
-    ('/records/record-v1.0.0.json',
-     ('records-record-v1.0.0', 'record-v1.0.0')),
-])
-def test_schema_to_index(schema_url, result):
-    """Test conversion of schema to index name and document type."""
-    assert result == schema_to_index(schema_url)
 
 
 def test_load_entry_point_group(template_entrypoints):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2018 CERN.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+import pytest
+from mock import patch
+
+from invenio_search.utils import schema_to_index
+
+
+@pytest.mark.parametrize(
+    ('schema, expected, index_names'),
+    (
+        (
+            'records/record-v1.0.0.json',
+            ('records-record-v1.0.0', 'record-v1.0.0'),
+            None,
+        ),
+        (
+            '/records/record-v1.0.0.json',
+            ('records-record-v1.0.0', 'record-v1.0.0'),
+            None,
+        ),
+        (
+            'default-v1.0.0.json',
+            ('default-v1.0.0', 'default-v1.0.0'),
+            None,
+        ),
+        (
+            'default-v1.0.0.json',
+            (None, None),
+            [],
+        ),
+        (
+            'invalidextension',
+            (None, None),
+            None,
+        ),
+    ),
+)
+def test_schema_to_index(schema, expected, index_names, app):
+
+    result = schema_to_index(schema, index_names=index_names)
+    assert result == expected
+
+
+def test_schema_to_index_prefixes_indices(app):
+
+    new_conf = {'SEARCH_INDEX_PREFIX': 'prefix-'}
+    with patch.dict(app.config, new_conf):
+        result = schema_to_index('default-v1.0.0.json')
+
+        assert result == ('prefix-default-v1.0.0', 'default-v1.0.0')


### PR DESCRIPTION
Now using the setting `SEARCH_INDEX_PREFIX` you can define a prefix to
use for all your indices.


This partially addresses #129

Signed-off-by: David Caro <david@dcaro.es>