### PR TITLE
installation: limit elasticsearch-dsl<6.2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ extras_require = {
     ],
     'elasticsearch6': [
         'elasticsearch>=6.0.0,<7.0.0',
-        'elasticsearch-dsl>=6.0.0,<7.0.0',
+        'elasticsearch-dsl>=6.0.0,<6.2.0',
     ],
     'records': [
         'invenio-records>=1.0.0',

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -61,6 +61,7 @@ def test_init(app, template_entrypoints):
 
     with runner.isolated_filesystem():
         result = runner.invoke(cmd, ['init', '--force'], obj=script_info)
+        assert result.exit_code == 0
         if ES_VERSION[0] == 2:
             assert current_search_client.indices.exists_template(
                 'subdirectory-file-download-v1')


### PR DESCRIPTION
* Adds upper limit to elasticsearch-dsl < 6.2.0, because of breaking changes in empty query handling.

Closes #149 

Signed-off-by: Dinos Kousidis <dinos.kousidis@cern.ch>