### PR TITLE
config: add SEARCH_CLIENT_CONFIG variable

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -316,7 +316,11 @@ texinfo_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/': None}
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/', None),
+    'elasticsearch': (
+        'https://elasticsearch-py.readthedocs.io/en/master/', None),
+}
 
 # Autodoc configuraton.
 autoclass_content = 'both'

--- a/invenio_search/config.py
+++ b/invenio_search/config.py
@@ -40,6 +40,28 @@ the different nodes. Please see
 for further details.
 """
 
+SEARCH_CLIENT_CONFIG = None
+"""Elasticsearch client configuration.
+
+If provided, this configuration dictionary will be passed to the initialization
+of the :class:`elasticsearch:elasticsearch.Elasticsearch` client instance used
+by the module.
+
+
+If not set, for the ``hosts`` key, :py:data:`.SEARCH_ELASTIC_HOSTS` will be
+used and for the ``connection_class`` key
+:class:`elasticsearch:elasticsearch.connection.RequestsHttpConnection`.
+
+Example value:
+
+.. code-block:: python
+
+   # e.g. for smaller/slower machines or development/CI you might want to be a
+   # bit more relaxed in terms of timeouts and failure retries.
+   dict(timeout=30, max_retries=5,
+   )
+"""
+
 SEARCH_MAPPINGS = None  # loads all mappings and creates aliases for them
 """List of aliases for which, their search mappings should be created.
 

--- a/invenio_search/ext.py
+++ b/invenio_search/ext.py
@@ -16,6 +16,8 @@ import os
 import warnings
 
 from elasticsearch import VERSION as ES_VERSION
+from elasticsearch import Elasticsearch
+from elasticsearch.connection import RequestsHttpConnection
 from pkg_resources import iter_entry_points, resource_filename, \
     resource_isdir, resource_listdir
 from werkzeug.utils import cached_property
@@ -186,13 +188,11 @@ class _SearchState(object):
 
     def _client_builder(self):
         """Build Elasticsearch client."""
-        from elasticsearch import Elasticsearch
-        from elasticsearch.connection import RequestsHttpConnection
-
-        return Elasticsearch(
-            hosts=self.app.config.get('SEARCH_ELASTIC_HOSTS'),
-            connection_class=RequestsHttpConnection,
-        )
+        client_config = self.app.config.get('SEARCH_CLIENT_CONFIG') or {}
+        client_config.setdefault(
+            'hosts', self.app.config.get('SEARCH_ELASTIC_HOSTS'))
+        client_config.setdefault('connection_class', RequestsHttpConnection)
+        return Elasticsearch(**client_config)
 
     @property
     def client(self):

--- a/tests/test_invenio_search.py
+++ b/tests/test_invenio_search.py
@@ -13,6 +13,7 @@ from __future__ import absolute_import, print_function
 
 import pytest
 from elasticsearch import VERSION as ES_VERSION
+from elasticsearch.connection import RequestsHttpConnection
 from flask import Flask
 from mock import patch
 
@@ -37,6 +38,19 @@ def test_init():
     assert 'invenio-search' not in app.extensions
     ext.init_app(app)
     assert 'invenio-search' in app.extensions
+
+
+def test_client_config():
+    """Test Elasticsearch client configuration."""
+    app = Flask('testapp')
+    app.config['SEARCH_CLIENT_CONFIG'] = {'timeout': 30, 'foo': 'bar'}
+    with patch('elasticsearch.Elasticsearch.__init__') as mock_es_init:
+        mock_es_init.return_value = None
+        ext = InvenioSearch(app)
+        es_client = ext.client  # trigger client initialization
+        mock_es_init.assert_called_once_with(
+            hosts=None, connection_class=RequestsHttpConnection,
+            timeout=30, foo='bar')
 
 
 def test_flush_and_refresh(app):


### PR DESCRIPTION
* Adds the "SEARCH_CLIENT_CONFIG" config variable, allowing more
  flexibility for the Elasticsearch client initialization (closes #82)