### PR TITLE
ext: add suffix to index names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,18 +27,15 @@ services:
 
 env:
   global:
-    - ES2_DOWNLOAD_URL="https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.4.2/elasticsearch-2.4.2.tar.gz"
-    - ES5_DOWNLOAD_URL="https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.6.4.tar.gz"
     - ES6_DOWNLOAD_URL="https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.2.0.tar.gz"
     - ES7_DOWNLOAD_URL="https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.0.1-linux-x86_64.tar.gz"
     - ES_HOST=127.0.0.1
     - SQLALCHEMY_DATABASE_URI="postgresql+psycopg2://postgres@localhost:5432/invenio"
   matrix:
-    - REQUIREMENTS=lowest EXTRAS=all,elasticsearch2 ES_URL=$ES2_DOWNLOAD_URL
-    - REQUIREMENTS=lowest EXTRAS=all,elasticsearch5 ES_URL=$ES5_DOWNLOAD_URL
-    - REQUIREMENTS=release EXTRAS=all,elasticsearch5 ES_URL=$ES5_DOWNLOAD_URL DEPLOY=true
+    - REQUIREMENTS=lowest EXTRAS=all,elasticsearch6 ES_URL=$ES6_DOWNLOAD_URL
+    - REQUIREMENTS=lowest EXTRAS=all,elasticsearch7 ES_URL=$ES7_DOWNLOAD_URL
     - REQUIREMENTS=release EXTRAS=all,elasticsearch6 ES_URL=$ES6_DOWNLOAD_URL
-    - REQUIREMENTS=devel EXTRAS=all,elasticsearch5 ES_URL=$ES5_DOWNLOAD_URL
+    - REQUIREMENTS=release EXTRAS=all,elasticsearch7 ES_URL=$ES7_DOWNLOAD_URL
     - REQUIREMENTS=devel EXTRAS=all,elasticsearch6 ES_URL=$ES6_DOWNLOAD_URL
     - REQUIREMENTS=devel EXTRAS=all,elasticsearch7 ES_URL=$ES7_DOWNLOAD_URL
 
@@ -52,7 +49,6 @@ python:
 matrix:
   fast_finish: true
   allow_failures:
-    - env: REQUIREMENTS=devel EXTRAS=all,elasticsearch5 ES_URL=$ES5_DOWNLOAD_URL
     - env: REQUIREMENTS=devel EXTRAS=all,elasticsearch6 ES_URL=$ES6_DOWNLOAD_URL
     - env: REQUIREMENTS=devel EXTRAS=all,elasticsearch7 ES_URL=$ES7_DOWNLOAD_URL
 

--- a/examples/app-teardown.sh
+++ b/examples/app-teardown.sh
@@ -15,4 +15,4 @@ export FLASK_APP=app.py
 [ -e "$DIR/instance" ] && rm -Rf $DIR/instance
 
 # Delete indices
-flask index destroy --yes-i-know
+flask index delete demo* --force --yes-i-know

--- a/invenio_search/api.py
+++ b/invenio_search/api.py
@@ -19,7 +19,7 @@ from elasticsearch_dsl.query import Bool, Ids
 from flask import current_app, request
 
 from .proxies import current_search_client
-from .utils import prefix_index
+from .utils import build_alias_name
 
 
 class DefaultFilter(object):
@@ -131,7 +131,7 @@ class BaseRecordsSearch(Search):
         class RecordsFacetedSearch(FacetedSearch):
             """Pass defaults from ``cls.Meta`` object."""
 
-            index = prefix_index(app=current_app, index=search_._index[0])
+            index = build_alias_name(search_._index[0])
             doc_types = getattr(search_.Meta, 'doc_types', ['_all'])
             fields = getattr(search_.Meta, 'fields', ('*', ))
             facets = getattr(search_.Meta, 'facets', {})
@@ -200,22 +200,20 @@ class RecordsSearch(BaseRecordsSearch):
         if not isinstance(_index_param, PrefixedIndexList):
             if isinstance(_index_param, (tuple, list)):
                 _prefixed_index_list = [
-                    prefix_index(app=current_app,
-                                 index=_index) for _index in _index_param]
+                    build_alias_name(_index)
+                    for _index in _index_param
+                ]
                 kwargs.update({'index': _prefixed_index_list})
             elif isinstance(_index_param, six.string_types):
                 _splitted_index = _index_param.strip().split(',')
                 if len(_splitted_index) > 1:
                     _prefix_index_list = [
-                        prefix_index(current_app, _index)
+                        build_alias_name(_index)
                         for _index in _splitted_index]
                     _prefix_index_param = ','.join(_prefix_index_list)
-                    kwargs.update({
-                        'index': _prefix_index_param})
+                    kwargs.update({'index': _prefix_index_param})
                 else:
-                    kwargs.update({
-                        'index': prefix_index(app=current_app,
-                                              index=_index_param)})
+                    kwargs.update({'index': build_alias_name(_index_param)})
                 _index_param = [_index_param]
             self._original_index = _index_param
 

--- a/invenio_search/cli.py
+++ b/invenio_search/cli.py
@@ -70,13 +70,13 @@ def init(force):
     click.secho('Creating indexes...', fg='green', bold=True, file=sys.stderr)
     with click.progressbar(
             current_search.create(ignore=[400] if force else None),
-            length=current_search.number_of_indexes) as bar:
+            length=len(current_search.mappings)) as bar:
         for name, response in bar:
             bar.label = name
     click.secho('Putting templates...', fg='green', bold=True, file=sys.stderr)
     with click.progressbar(
             current_search.put_templates(ignore=[400] if force else None),
-            length=len(current_search.templates.keys())) as bar:
+            length=len(current_search.templates)) as bar:
         for response in bar:
             bar.label = response
 
@@ -93,7 +93,7 @@ def destroy(force):
     click.secho('Destroying indexes...', fg='red', bold=True, file=sys.stderr)
     with click.progressbar(
             current_search.delete(ignore=[400, 404] if force else None),
-            length=current_search.number_of_indexes) as bar:
+            length=len(current_search.mappings)) as bar:
         for name, response in bar:
             bar.label = name
 

--- a/invenio_search/errors.py
+++ b/invenio_search/errors.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2019 CERN.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Invenio search errors."""
+
+
+class IndexAlreadyExistsError(Exception):
+    """Raised when an index or alias already exists during index creation."""

--- a/invenio_search/utils.py
+++ b/invenio_search/utils.py
@@ -9,52 +9,101 @@
 """Utility functions for search engine."""
 
 import os
+import time
 
+import six
 from flask import current_app
 
+from .proxies import current_search, current_search_client
 
-def prefix_index(app, index):
+
+def timestamp_suffix():
+    """Generate a suffix based on the current time."""
+    return '-' + str(int(time.time()))
+
+
+def prefix_index(index, prefix=None, app=None):
     """Prefixes the given index if needed.
 
-    :param app: Flask app to get the config from.
     :param index: Name of the index to prefix.
+    :param prefix: Force a prefix.
+    :param app: Flask app to get the prefix config from.
     :returns: A string with the new index name prefixed if needed.
     """
-    index_prefix = app.config['SEARCH_INDEX_PREFIX'] or ''
+    app = app or current_app
+    index_prefix = (prefix if prefix is not None
+                    else (app.config.get('SEARCH_INDEX_PREFIX')) or '')
     return index_prefix + index
 
 
-def build_index_name(app, *parts):
+def suffix_index(index, suffix=None, app=None):
+    """Suffixes the given index.
+
+    :param index: Name of the index to prefix.
+    :param suffix: The suffix to append to the index name.
+    :param app: Flask app to get the "invenio-search" extension from.
+    :returns: A string with the new index name suffixed.
+    """
+    search_ext = app.extensions['invenio-search'] if app else current_search
+    suffix = suffix if suffix is not None else search_ext.current_suffix
+    return index + suffix
+
+
+def build_index_from_parts(*parts):
     """Build an index name from parts.
 
-    :param parts: Parts that should be combined to make an index name.
+    :param parts: String values that will be joined by dashes ("-").
     """
-    base_index = os.path.splitext(
-        '-'.join([part for part in parts if part])
-    )[0]
-
-    return prefix_index(app=app, index=base_index)
+    return '-'.join([part for part in parts if part])
 
 
-def schema_to_index(schema, index_names=None):
+def build_alias_name(index, prefix=None, app=None):
+    """Build an alias name.
+
+    :param index: Name of the index.
+    :param prefix: The prefix to prepend to the index name.
+    """
+    return build_index_name(index, prefix=prefix, suffix='', app=app)
+
+
+def build_index_name(index, prefix=None, suffix=None, app=None):
+    """Build an index name.
+
+    :param index: Name of the index.
+    :param prefix: The prefix to prepend to the index name.
+    :param suffix: The suffix to append to the index name.
+    :param app: Flask app passed to ``prefix_index`` and ``suffix_index``.
+    """
+    if not isinstance(index, six.string_types):
+        index = build_index_from_parts(*index)
+    index = prefix_index(index, prefix=prefix, app=app)
+    index = suffix_index(index, suffix=suffix, app=app)
+    return index
+
+
+def schema_to_index(schema, index_names=None, prefix=''):
     """Get index/doc_type given a schema URL.
 
     :param schema: The schema name
     :param index_names: A list of index name.
+    :param prefix: The prefix to prepend to the index name.
     :returns: A tuple containing (index, doc_type).
     """
     parts = schema.split('/')
-    doc_type = os.path.splitext(parts[-1])
+    doc_type, ext = os.path.splitext(parts[-1])
+    parts[-1] = doc_type
 
-    if doc_type[1] not in {'.json', }:
+    if ext not in {'.json', }:
         return (None, None)
 
     if index_names is None:
-        return (build_index_name(current_app, *parts), doc_type[0])
+        index = build_alias_name(parts, prefix=prefix)
+        return index, doc_type
 
     for start in range(len(parts)):
-        index_name = build_index_name(current_app, *parts[start:])
-        if index_name in index_names:
-            return (index_name, doc_type[0])
+        name = build_index_from_parts(*parts[start:])
+        if name in index_names:
+            index = build_alias_name(name, prefix=prefix)
+            return index, doc_type
 
     return (None, None)

--- a/setup.py
+++ b/setup.py
@@ -50,9 +50,6 @@ extras_require = {
         'elasticsearch>=7.0.0,<8.0.0',
         'elasticsearch-dsl>=7.0.0,<8.0.0',
     ],
-    'records': [
-        'invenio-records>=1.0.0',
-    ],
     'tests': tests_require,
 }
 
@@ -64,8 +61,6 @@ for name, reqs in extras_require.items():
         continue
     extras_require['all'].extend(reqs)
 
-
-extras_require['tests'] += extras_require['records']
 
 setup_requires = [
     'pytest-runner>=2.6.2',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,35 +47,6 @@ def app():
     shutil.rmtree(instance_path)
 
 
-@pytest.fixture()
-def records_app(request):
-    """Initialize InvenioRecords."""
-    app = Flask('records_testapp')
-    app.config.update(
-        TESTING=True,
-        SQLALCHEMY_DATABASE_URI=os.environ.get(
-            'SQLALCHEMY_DATABASE_URI', 'sqlite:///test.db'
-        ),
-    )
-    InvenioDB(app)
-    from invenio_records import InvenioRecords
-    from invenio_db import db
-    InvenioRecords(app)
-    InvenioSearch(app)
-
-    with app.app_context():
-        if not database_exists(str(db.engine.url)):
-            create_database(str(db.engine.url))
-        db.create_all()
-
-    def teardown():
-        with app.app_context():
-            db.drop_all()
-
-    request.addfinalizer(teardown)
-    return app
-
-
 def mock_iter_entry_points_factory(data, mocked_group):
     """Create a mock iter_entry_points function."""
     from pkg_resources import iter_entry_points

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,8 +13,10 @@ from __future__ import absolute_import, print_function
 
 import ast
 
+import pytest
 from click.testing import CliRunner
 from elasticsearch import VERSION as ES_VERSION
+from elasticsearch.exceptions import NotFoundError
 from flask.cli import ScriptInfo
 from mock import patch
 
@@ -24,7 +26,9 @@ from invenio_search.proxies import current_search_client
 
 def test_init(app, template_entrypoints):
     """Run client initialization."""
+    suffix = '-abc'
     search = app.extensions['invenio-search']
+    search._current_suffix = suffix
     search.register_mappings('records', 'mock_module.mappings')
 
     assert 'records' in search.aliases
@@ -33,12 +37,18 @@ def test_init(app, template_entrypoints):
         'records-bibliographic',
         'records-default-v1.0.0'
     }
+    assert set(search.aliases['records']['records-authorities']) == {
+        'records-authorities-authority-v1.0.0',
+    }
+    assert set(search.aliases['records']['records-bibliographic']) == {
+        'records-bibliographic-bibliographic-v1.0.0',
+    }
     assert set(search.mappings.keys()) == {
         'records-authorities-authority-v1.0.0',
         'records-bibliographic-bibliographic-v1.0.0',
         'records-default-v1.0.0'
     }
-    assert 6 == search.number_of_indexes
+    assert 3 == len(search.mappings)
 
     with patch('invenio_search.ext.iter_entry_points',
                return_value=template_entrypoints('invenio_search.templates')):
@@ -73,7 +83,7 @@ def test_init(app, template_entrypoints):
         assert 0 == result.exit_code
 
     aliases = current_search_client.indices.get_alias()
-    assert 5 == sum(len(idx.get('aliases', {})) for idx in aliases.values())
+    assert 8 == sum(len(idx.get('aliases', {})) for idx in aliases.values())
 
     assert current_search_client.indices.exists(list(search.mappings.keys()))
 
@@ -90,8 +100,10 @@ def test_init(app, template_entrypoints):
 
 def test_list(app):
     """Run listing of mappings."""
+    suffix = '-abc'
     app.config['SEARCH_MAPPINGS'] = ['records']
     search = app.extensions['invenio-search']
+    search._current_suffix = suffix
     search.register_mappings('authors', 'mock_module.mappings')
     search.register_mappings('records', 'mock_module.mappings')
 
@@ -126,3 +138,33 @@ def test_check(app):
                return_value=(ES_VERSION[0] + 1, 0, 0)):
         result = runner.invoke(cmd, ['check'], obj=script_info)
         assert result.exit_code != 0
+
+
+def test_create_put_and_delete(app):
+    runner = CliRunner()
+    script_info = ScriptInfo(create_app=lambda info: app)
+    name = 'test-index-name'
+
+    result = runner.invoke(cmd, [
+        'create', '--verbose', name,
+        '--body', './tests/mock_module/mappings/authors/authors-v1.0.0.json',
+    ], obj=script_info)
+    assert result.exit_code == 0
+    assert name in list(current_search_client.indices.get('*').keys())
+
+    doc_type = '_doc' if ES_VERSION[0] > 5 else 'recid'
+    result = runner.invoke(cmd, [
+        'put', name, doc_type,
+        '--verbose', '--identifier', 1,
+        '--body', './tests/mock_module/mappings/authors/authors-v1.0.0.json',
+    ], obj=script_info)
+    assert result.exit_code == 0
+    current_search_client.get(index=name, doc_type=doc_type, id=1)
+    with pytest.raises(NotFoundError):
+        current_search_client.get(index=name, doc_type=doc_type, id=2)
+
+    result = runner.invoke(cmd, [
+        'delete', '--verbose', '--yes-i-know', '--force', name,
+    ], obj=script_info)
+    assert result.exit_code == 0
+    assert name not in list(current_search_client.indices.get('*').keys())

--- a/tests/test_invenio_search.py
+++ b/tests/test_invenio_search.py
@@ -11,13 +11,15 @@
 
 from __future__ import absolute_import, print_function
 
+from collections import defaultdict
+
 import pytest
 from elasticsearch import VERSION as ES_VERSION
-from elasticsearch.connection import RequestsHttpConnection
 from flask import Flask
 from mock import patch
 
 from invenio_search import InvenioSearch, current_search, current_search_client
+from invenio_search.errors import IndexAlreadyExistsError
 
 
 def test_version():
@@ -134,6 +136,17 @@ def test_load_entry_point_group(template_entrypoints):
 ])
 def test_whitelisted_aliases(app, aliases_config, expected_aliases):
     """Test functionality of active aliases configuration variable."""
+    all_aliases = dict(
+        authors=['authors', 'authors-authors-v1.0.0'],
+        records=[
+            'records',
+            'records-default-v1.0.0',
+            'records-authorities',
+            'records-authorities-authority-v1.0.0',
+            'records-bibliographic',
+            'records-bibliographic-bibliographic-v1.0.0',
+        ]
+    )
 
     orig = app.config['SEARCH_MAPPINGS']
 
@@ -152,14 +165,76 @@ def test_whitelisted_aliases(app, aliases_config, expected_aliases):
     if expected_aliases == []:
         assert 0 == len(aliases)
     else:
-        assert current_search_client.indices.exists(expected_aliases)
+        for expected_alias in expected_aliases:
+            all_expected = all_aliases[expected_alias]
+            assert current_search_client.indices.exists(all_expected)
 
     app.config['SEARCH_MAPPINGS'] = orig
 
 
+@pytest.mark.parametrize(
+    ('suffix', 'create_index', 'create_alias', 'expected'), [
+        ('', 'authors-authors-v1.0.0', None, []),
+        ('', None, 'authors-authors-v1.0.0', []),
+        ('-abc', 'authors-authors-v1.0.0', None, []),
+        ('-test', 'authors-authors-not-exist', None, [
+            'authors-authors-v1.0.0-test',
+            'authors-authors-v1.0.0',
+            'authors',
+        ]),
+    ]
+)
+def test_creating_alias_existing_index(app, suffix, create_index, create_alias,
+                                       expected):
+    """Test creating new alias and index where there already exists one."""
+    search = app.extensions['invenio-search']
+    search.register_mappings('authors', 'mock_module.mappings')
+    search._current_suffix = suffix
+    current_search_client.indices.delete_alias('_all', '_all', ignore=[400,
+                                                                       404])
+    current_search_client.indices.delete('*')
+    new_indexes = []
+    if create_index:
+        current_search_client.indices.create(index=create_index)
+        new_indexes.append(create_index)
+    if create_alias:
+        write_alias_index = '{}-suffix'.format(create_alias)
+        current_search_client.indices.create(
+            index=write_alias_index
+        )
+        new_indexes.append(write_alias_index)
+        current_search_client.indices.put_alias(
+            index=write_alias_index,
+            name=create_alias,
+        )
+    if expected:
+        results = list(current_search.create(ignore=None))
+        assert len(results) == len(expected)
+        for result in results:
+            assert result[0] in expected
+        indices = current_search_client.indices.get('*')
+        index_names = list(indices.keys())
+        alias_names = []
+        for index in index_names:
+            alias_names.extend(list(indices[index]['aliases'].keys()))
+        for index, _ in results:
+            if index.endswith(suffix):
+                assert sorted(index_names) == sorted([index] + new_indexes)
+            else:
+                assert index in alias_names
+    else:
+        with pytest.raises(Exception):
+            results = list(current_search.create(ignore=None))
+        indices = current_search_client.indices.get('*')
+        index_names = list(indices.keys())
+        assert index_names == new_indexes
+        if create_index:
+            assert len(indices[create_index]['aliases']) == 0
+
+
 @pytest.mark.parametrize(('aliases_config', 'prefix', 'expected_aliases'), [
-    (['authors'], 'test-', ['test-authors']),
-    (['authors', 'records'], 'dev-', ['dev-records', 'dev-authors']),
+    (['authors'], 'test-', ['authors']),
+    (['authors', 'records'], 'dev-', ['records', 'authors']),
 ])
 def test_prefix_search_mappings(app, aliases_config, prefix, expected_aliases):
     """Test that indices are created when prefix & search mappings are set."""
@@ -182,21 +257,44 @@ def test_prefix_search_mappings(app, aliases_config, prefix, expected_aliases):
 def _test_prefix_indices(app, prefix_value):
     """Assert that each index name contains the prefix."""
     app.config['SEARCH_INDEX_PREFIX'] = prefix_value
+    suffix = '-abc'
+    prefix = prefix_value or ''
     search = app.extensions['invenio-search']
+    search._current_suffix = suffix
     search.register_mappings('records', 'mock_module.mappings')
-
-    assert set(search.mappings.keys()) == {
-        '{0}records-authorities-authority-v1.0.0'.format(prefix_value or ''),
-        '{0}records-bibliographic-bibliographic-v1.0.0'.format(
-            prefix_value or ''),
-        '{0}records-default-v1.0.0'.format(prefix_value or '')
-    }
 
     # clean-up in case something failed previously
     current_search_client.indices.delete('*')
     # create indices and test
     list(search.create())
-    assert current_search_client.indices.exists(list(search.mappings.keys()))
+    es_indices = current_search_client.indices.get_alias()
+
+    def _f(name):  # formatting helper
+        return name.format(p=prefix, s=suffix)
+
+    assert set(es_indices.keys()) == {
+        _f('{p}records-authorities-authority-v1.0.0{s}'),
+        _f('{p}records-bibliographic-bibliographic-v1.0.0{s}'),
+        _f('{p}records-default-v1.0.0{s}'),
+    }
+    # Build set of aliases
+    es_aliases = defaultdict(set)
+    for index, info in es_indices.items():
+        for alias in info.get('aliases', {}):
+            es_aliases[alias].add(index)
+
+    auth_idx = {_f('{p}records-authorities-authority-v1.0.0{s}')}
+    bib_idx = {_f('{p}records-bibliographic-bibliographic-v1.0.0{s}')}
+    default_idx = {_f('{p}records-default-v1.0.0{s}')}
+    all_indices = auth_idx | bib_idx | default_idx
+    assert es_aliases == {
+        _f('{p}records-authorities-authority-v1.0.0'): auth_idx,
+        _f('{p}records-bibliographic-bibliographic-v1.0.0'): bib_idx,
+        _f('{p}records-default-v1.0.0'): default_idx,
+        _f('{p}records-authorities'): auth_idx,
+        _f('{p}records-bibliographic'): bib_idx,
+        _f('{p}records'): all_indices,
+    }
     # clean-up
     current_search_client.indices.delete('*')
 
@@ -221,7 +319,6 @@ def test_indices_prefix_some_value(app):
 
 def _test_prefix_templates(app, prefix_value, template_entrypoints):
     """Assert that templates take into account the prefix name."""
-
     def _contains_prefix(prefix_value, string_or_list):
         """Return True if the prefix value is in the input list or string."""
         if isinstance(string_or_list, list):
@@ -230,7 +327,7 @@ def _test_prefix_templates(app, prefix_value, template_entrypoints):
         else:
             return prefix_value in string_or_list
 
-    def _test_prefix_replaced_in_body(prefix_value, tpl_key):
+    def _test_prefix_replaced_in_body(name, prefix_value, tpl_key):
         """Test that the prefix is replaced in the body when defined."""
         if prefix_value:
             tpl = current_search_client.indices.get_template(name)
@@ -241,33 +338,41 @@ def _test_prefix_templates(app, prefix_value, template_entrypoints):
     search = app.extensions['invenio-search']
     with patch('invenio_search.ext.iter_entry_points',
                return_value=template_entrypoints('invenio_search.templates')):
+        # clean-up in case something failed previously
+        current_search_client.indices.delete_template('*')
         # create templates
         list(search.put_templates())
 
         if ES_VERSION[0] == 2:
             assert len(search.templates.keys()) == 2
-            name = '{0}record-view-v1'.format(prefix_value or '')
+            name = 'record-view-v1'
+            prefixed = (prefix_value or '') + name
             assert name in search.templates
-            assert current_search_client.indices.exists_template(name)
-            name = '{0}subdirectory-file-download-v1'.format(
-                prefix_value or '')
+            assert current_search_client.indices.exists_template(prefixed)
+            _test_prefix_replaced_in_body(prefixed, prefix_value, 'template')
+            name = 'subdirectory-file-download-v1'
+            prefixed = (prefix_value or '') + name
             assert name in search.templates
-            assert current_search_client.indices.exists_template(name)
-            _test_prefix_replaced_in_body(prefix_value, 'template')
+            assert current_search_client.indices.exists_template(prefixed)
+            _test_prefix_replaced_in_body(prefixed, prefix_value, 'template')
         elif ES_VERSION[0] == 5:
             assert len(search.templates.keys()) == 1
-            name = '{0}record-view-v{1}'.format(
-                prefix_value or '', ES_VERSION[0])
+            name = 'record-view-v{0}'.format(ES_VERSION[0])
+            prefixed = (prefix_value or '') + name
             assert name in search.templates
-            assert current_search_client.indices.exists_template(name)
-            _test_prefix_replaced_in_body(prefix_value, 'template')
+            assert current_search_client.indices.exists_template(prefixed)
+            _test_prefix_replaced_in_body(prefixed, prefix_value, 'template')
         else:
             assert len(search.templates.keys()) == 1
-            name = '{0}record-view-v{1}'.format(
-                prefix_value or '', ES_VERSION[0])
+            name = 'record-view-v{0}'.format(ES_VERSION[0])
+            prefixed = (prefix_value or '') + name
             assert name in search.templates
-            assert current_search_client.indices.exists_template(name)
-            _test_prefix_replaced_in_body(prefix_value, 'index_patterns')
+            assert current_search_client.indices.exists_template(prefixed)
+            _test_prefix_replaced_in_body(
+                prefixed, prefix_value, 'index_patterns')
+
+        # clean-up
+        current_search_client.indices.delete_template('*')
 
 
 def test_templates_prefix_empty_value(app, template_entrypoints):
@@ -286,3 +391,23 @@ def test_templates_prefix_some_value(app, template_entrypoints):
     """Test templates creation with a prefix value `myprefix-`."""
     prefix_value = 'myprefix-'
     _test_prefix_templates(app, prefix_value, template_entrypoints)
+
+
+def test_current_suffix(app):
+    """Test generating current suffix."""
+    search = app.extensions['invenio-search']
+    suffix = search.current_suffix
+    assert suffix == search.current_suffix
+
+
+def test_not_dry_run_and_index_exists(app):
+    """Test create_index and no dry run when index exists."""
+    current_search_client.indices.delete('*')
+    current_search_client.indices.create(
+        index='records-default-v1.0.0',
+        body=""
+    )
+    search = app.extensions['invenio-search']
+    search.register_mappings('records', 'mock_module.mappings')
+    with pytest.raises(IndexAlreadyExistsError):
+        list(search.create())


### PR DESCRIPTION
The suffix is a timestamp and will be added to new indices. An alias
will be created with the same name as the index without the suffix.

Closes #162.