### PR TITLE
invenio_search: Add ignore_existing option to create.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,11 @@
 Changes
 =======
 
+Version 1.2.2 (released 2019-08--8)
+
+- Adds option ignore_existing which is ignoring indexes which are already in ES.
+- Adds option to create/delete only selected indexes.
+
 Version 1.2.1 (released 2019-07-31)
 
 - Unpins ``urllib3`` and ``idna`` since ``requests`` is not a direct dependency

--- a/invenio_search/version.py
+++ b/invenio_search/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = '1.2.1'
+__version__ = '1.2.2'


### PR DESCRIPTION
Currently there is no way to run create to add missing indexes and it's not possible to create/delete only specified indexes through invenio-search API.
This PR if fixing this problem.

* Adds option `ignore_existing` which is ignoring indexes which are already in ES.
* Adds option to create/delete only selected indexes.