### PR TITLE
release: v1.4.2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,10 @@
 Changes
 =======
 
+Version 1.4.2 (released 2021-07-20)
+
+- Pin elasticsearch to lower than 7.14 due to built in product check.
+
 Version 1.4.1 (released 2020-10-19)
 
 - Fix bouncing search results for BaseRecordSearchV2.

--- a/invenio_search/version.py
+++ b/invenio_search/version.py
@@ -13,4 +13,4 @@ This file is imported by ``invenio_search.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = '1.4.1'
+__version__ = '1.4.2'

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ extras_require = {
         'elasticsearch-dsl>=6.0.0,<6.2.0',
     ],
     'elasticsearch7': [
-        'elasticsearch>=7.0.0,<8.0.0',
+        'elasticsearch>=7.0.0,<7.14',
         'elasticsearch-dsl>=7.0.0,<8.0.0',
     ],
     'tests': tests_require,


### PR DESCRIPTION
elasticsearch-py product check will make any invenio-search/indexer operation fail. Therefore we need to pin it down. As stated [here](https://github.com/elastic/elasticsearch-py/issues/1639#issuecomment-883368588) there will be no more releases of the OSS version.

Note the fix might be needed for older releases although according to the EOL, v3.3 is out of support so it should be good since this would be picked by invenio v3.4.0 and v3.4.1