### PR TITLE
fix: avoid closing db session

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,13 +16,13 @@ on:
     branches: master
   schedule:
     # * is a special character in YAML so you have to quote this string
-    - cron:  '0 3 * * 6'
+    - cron: "0 3 * * 6"
   workflow_dispatch:
     inputs:
       reason:
-        description: 'Reason'
+        description: "Reason"
         required: false
-        default: 'Manual trigger'
+        default: "Manual trigger"
 
 jobs:
   Python:

--- a/invenio_search/ext.py
+++ b/invenio_search/ext.py
@@ -83,9 +83,8 @@ class _SearchState(object):
             loaded_ep = ep.load()
 
             if callable(loaded_ep):
-                with self.app.app_context():
-                    for template_dir in loaded_ep():
-                        result.append(self.register_templates(template_dir))
+                for template_dir in loaded_ep():
+                    result.append(self.register_templates(template_dir))
             else:
                 result.append(self.register_templates(ep.module_name))
 


### PR DESCRIPTION
Using `with self.app.app_context():` closes the current DB session on `__exit__`, causing a `sqlalchemy.orm.exc.DetachedInstanceError` when accessing any property of the object expected in the session. This error occurs only the first time index_templates are loaded, such as when indexing the very first record.
Subsequent accesses won't trigger this issue due to the @cached_property, preventing reloading of index_templates.

Bonus 👀: using [Conventional Commits](https://www.conventionalcommits.org)